### PR TITLE
feat(ci): add first CI job (test+build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: Node CI
-
 on: [push]
 
 jobs:
-  build:
+  setup:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -26,8 +25,55 @@ jobs:
         if: steps.cache_node_modules_id.outputs.cache-hit != 'true'
         run: yarn --check-files --frozen-lockfile --non-interactive --ignore-optional
 
+  test:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Restore node_modules
+        id: node_modules_cache_id
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node-version }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '**/yarn.lock')) }}
+
       - name: Test
         run: yarn test
+
+  # lint:
+
+  build:
+    # needs: [lint, test]
+    needs: [test]
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Restore node_modules
+        id: node_modules_cache_id
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node-version }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '**/yarn.lock')) }}
 
       - name: Build
         run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.cache_node_modules_id.outputs.cache-hit != 'true'
-        run: yarn --check-files --frozen-lockfile --non-interactive
+        run: yarn --check-files --frozen-lockfile --non-interactive --ignore-optional
 
       - name: Test
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         node-version: [14.x]
 
     steps:
@@ -14,9 +15,16 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache node_modules
+        id: cache_node_modules_id
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node-version }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '**/yarn.lock')) }}
 
       - name: Install Dependencies
-        run: yarn
+        if: steps.cache_node_modules_id.outputs.cache-hit != 'true'
+        run: yarn --check-files --frozen-lockfile --non-interactive
 
       - name: Test
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Test
+        run: yarn test
+
+      - name: Build
+        run: yarn build

--- a/projects/debug-app/karma.conf.js
+++ b/projects/debug-app/karma.conf.js
@@ -2,7 +2,7 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = function (config) {
-  config.set({
+  const defaults = {
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
@@ -40,5 +40,23 @@ module.exports = function (config) {
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true
-  });
+  }
+
+  // Use headless mode on Github Actions, or it will not end forever.
+  if (process.env.GITHUB_ACTIONS) {
+    Object.assign(defaults, {
+      autoWatch: false,
+      browsers: ['ChromeHeadlessNoSandbox'],
+      singleRun: true,
+      customLaunchers: {
+        ChromeHeadlessNoSandbox: {
+          base: 'ChromeHeadless',
+          flags: ['--no-sandbox']
+        }
+      },
+      browserNoActivityTimeout: 60000
+    });
+  }
+
+  config.set(defaults);
 };


### PR DESCRIPTION
### Cache

#### 1st try (6d8b304)
```
Run actions/cache@v2
  with:
    path: node_modules
    key: ubuntu-latest-node-v14.x-deps-533041c07a9fb6aa54e5b02a49c85c169e9b23976d36270f5d97a8c2848cbd79
Cache not found for input keys: ubuntu-latest-node-v14.x-deps-533041c07a9fb6aa54e5b02a49c85c169e9b23976d36270f5d97a8c2848cbd79

Run yarn --check-files --frozen-lockfile --non-interactive
yarn install v1.22.10
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.13: The platform "linux" is incompatible with this module.
info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
[5/5] Building fresh packages...
Done in 32.01s.
```

#### 2nd try(de03418)

```
Run actions/cache@v2
Received 50436251 of 50436251 (100.0%), 47.9 MBs/sec
Cache Size: ~48 MB (50436251 B)
/usr/bin/tar --use-compress-program zstd -d -xf /home/runner/work/_temp/2a97b8da-d46a-4f1e-a083-8c8c19da531d/cache.tzst -P -C /home/runner/work/ng-sandbox/ng-sandbox
Cache restored successfully
Cache restored from key: ubuntu-latest-node-v14.x-deps-533041c07a9fb6aa54e5b02a49c85c169e9b23976d36270f5d97a8c2848cbd79
```